### PR TITLE
build: remove unused kotlinx.serialization.json runtime dependency

### DIFF
--- a/ghost-serialization/build.gradle.kts
+++ b/ghost-serialization/build.gradle.kts
@@ -28,7 +28,6 @@ kotlin {
             dependencies {
                 api(project(":ghost-api"))
                 api(libs.okio)
-                implementation(libs.kotlinx.serialization.json)
             }
         }
 


### PR DESCRIPTION
Remove `kotlinx.serialization.json` as an implementation dependency from the `ghost-serialization` core module.

The core runtime codebase has no imports or active references to kotlinx.serialization. The compatibility with annotations like `@SerialName` is resolved entirely at compile-time by the KSP compiler (`ghost-compiler`). Removing this dependency avoids forcing an unnecessary transitively inherited runtime dependency onto library consumers.

Special thanks to Reddit user u/rtc11 for pointing this out and helping improve the library footprint!